### PR TITLE
alioth: overlay: update rounded corner adjustment and fix quick qs offset height

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -12,11 +12,17 @@
      limitations under the License.
 -->
 <resources>
-    <!-- Radius of the software rounded corners. -->
+    <!-- Default paddings for content around the corners. -->
+    <dimen name="rounded_corner_content_padding">55px</dimen>
+
+    <!-- Default radius of the software rounded corners. -->
     <dimen name="rounded_corner_radius">126px</dimen>
 
-    <!-- Adjustment for software rounded corners since corners aren't perfectly round. -->
-    <dimen name="rounded_corner_radius_adjustment">22px</dimen>
+    <!-- Default adjustment for the software rounded corners since corners are not perfectly
+        round. This value is used when retrieving the "radius" of the rounded corner in cases
+        where the exact bezier curve cannot be retrieved.  This value will be subtracted from
+        rounded_corner_radius to more accurately provide a "radius" for the rounded corner. -->
+    <dimen name="rounded_corner_radius_adjustment">25px</dimen>
 
     <!-- Height of the status bar.
          Do not read this dimen directly. Use {@link SystemBarUtils#getStatusBarHeight} instead.
@@ -26,16 +32,15 @@
     <!-- Height of the status bar in portrait.
          Do not read this dimen directly. Use {@link SystemBarUtils#getStatusBarHeight} instead.
          -->
-    <dimen name="status_bar_height_portrait">38dp</dimen>
+    <dimen name="status_bar_height_portrait">@dimen/status_bar_height_default</dimen>
 
     <!-- Height of the status bar in landscape.
          Do not read this dimen directly. Use {@link SystemBarUtils#getStatusBarHeight} instead.
          -->
     <dimen name="status_bar_height_landscape">28dp</dimen>
 
-    <!-- Maximum vertical offset of statusbar for burn-in protection -->
-    <dimen name="status_bar_offset_max_y">1.5dp</dimen>
-
-    <!-- for 20dp of padding at 2.75px/dp at default density -->
-    <dimen name="rounded_corner_content_padding">55px</dimen>
+    <!-- Height of area above QQS where battery/time go.
+         Do not read this dimen directly. Use {@link SystemBarUtils#getQuickQsOffsetHeight} instead.
+         -->
+    <dimen name="quick_qs_offset_height">@dimen/status_bar_height_default</dimen>
 </resources>


### PR DESCRIPTION
This fixes the actual weird and unajusted status icons positionnings.

- after updating rounded corner masks, the adjustment no longer matches screen
- users can see that the radius of the fancy clipping path is slightly too high and thus causes visible pixel bleed in the top corners at mQsExpansion progress = 0.
- Reduce the radius by 3px to fix clipping issue.
- this is rather obvious after light qs


Change-Id: I09593708bfd95af106d538832727a3ffe98d0a02